### PR TITLE
[Arduino CLI] Allow equals signs in values of key-value pairs

### DIFF
--- a/arduino/codecard/cli.h
+++ b/arduino/codecard/cli.h
@@ -110,9 +110,13 @@ void loadDefaults(){
 }
 
 void evalInput(String input) {
-
-  String key = parseValue(input, '=', 0);
-  String val = parseValue(input, '=', 1);
+  // get the location of the first equals sign
+  int firstEqualsLoc = input.indexOf("=");
+  // the beginning of the string until the equals sign
+  String key = input.substring(0, firstEqualsLoc);
+  // after the first equals sign to the end of the string
+  String val = firstEqualsLoc == -1 ? "" : input.substring(firstEqualsLoc + 1);
+  
   if (key == "ls" || key == "ll") { listAll(); return; }
   if (key == "help") { help(); return; }
   if (key == "eraseall") { eraseAll(); return; } // not displayed under help


### PR DESCRIPTION
I wanted to use query string params in my URLs, and I found that anything after a second equals sign was cut off.

I've changed the implementation for this to use substrings. First, it gets the index of the first `=` in the input. Second, it takes a substring of all characters until it. Third, if there is an equals sign, it takes anything after the first equals sign to be the value.

